### PR TITLE
Calculator: new skill items, Skill Boosts moved on top, add auto-fill 

### DIFF
--- a/components/calculator/Calculator.tsx
+++ b/components/calculator/Calculator.tsx
@@ -120,9 +120,9 @@ function CalculatorContent({
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
             <div className="space-y-6">
+              <SkillBoosts />
               <GeneralBuffs />
               <GatheringBuffs />
-              <SkillBoosts />
             </div>
             <div className="space-y-6">
               <SkillItems />

--- a/utils/gamedata/agility-items.ts
+++ b/utils/gamedata/agility-items.ts
@@ -73,4 +73,13 @@ export const AGILITY_ITEMS: SkillItem[] = [
         goldValue: 0,
         goldPerSecond: 0,
     },
+    {
+        name: 'Sunfire Summit',
+        level: 105,
+        exp: 2520,
+        seconds: 262.5,
+        expPerSecond: 9.6,
+        goldValue: 0,
+        goldPerSecond: 0,
+    },
 ];

--- a/utils/gamedata/brewing-items.ts
+++ b/utils/gamedata/brewing-items.ts
@@ -82,4 +82,13 @@ export const BREWING_ITEMS: SkillItem[] = [
         goldValue: 1000,
         goldPerSecond: 5.6,
     },
+    {
+        name: 'Dragonfire Potion',
+        level: 105,
+        exp: 2950,
+        seconds: 90,
+        expPerSecond: 32.78,
+        goldValue: 2500,
+        goldPerSecond: 27.78,
+    },
 ];

--- a/utils/gamedata/carpentry-items.ts
+++ b/utils/gamedata/carpentry-items.ts
@@ -106,4 +106,14 @@ export const CARPENTRY_ITEMS: CarpentryItem[] = [
         goldPerSecond: 14,
         goldCost: 175,
     },
+    {
+        name: 'Ignis Heartwood',
+        level: 105,
+        exp: 2000,
+        seconds: 131.25,
+        expPerSecond: 15.24,
+        goldValue: 375,
+        goldPerSecond: 2.86,
+        goldCost: 175,
+    },
 ];

--- a/utils/gamedata/cooking-items.ts
+++ b/utils/gamedata/cooking-items.ts
@@ -166,6 +166,16 @@ export const MEAT_ITEMS: SkillItem[] = [
         goldPerSecond: 15,
         category: 'Meat',
     },
+    {
+        name: 'Apex Meat',
+        level: 100,
+        exp: 350,
+        seconds: 12,
+        expPerSecond: 29.17,
+        goldValue: 250,
+        goldPerSecond: 20.83,
+        category: 'Meat',
+    },
 ];
 
 // Dishes category

--- a/utils/gamedata/farming-items.ts
+++ b/utils/gamedata/farming-items.ts
@@ -82,4 +82,13 @@ export const FARMING_ITEMS: SkillItem[] = [
         goldValue: 4000,
         goldPerSecond: 22.2,
     },
+    {
+        name: 'Sunfire Berry',
+        level: 105,
+        exp: 2850,
+        seconds: 315,
+        expPerSecond: 9.05,
+        goldValue: 7500,
+        goldPerSecond: 23.81,
+    },
 ];

--- a/utils/gamedata/foraging-items.ts
+++ b/utils/gamedata/foraging-items.ts
@@ -82,4 +82,13 @@ export const FORAGING_ITEMS: SkillItem[] = [
         goldValue: 54,
         goldPerSecond: 4.3,
     },
+    {
+        name: 'Smoldering Mushroom',
+        level: 105,
+        exp: 210,
+        seconds: 21.875,
+        expPerSecond: 9.6,
+        goldValue: 85,
+        goldPerSecond: 3.89,
+    },
 ];

--- a/utils/gamedata/plundering-items.ts
+++ b/utils/gamedata/plundering-items.ts
@@ -96,4 +96,14 @@ export const PLUNDERING_ITEMS: PlunderingItem[] = [
         goldPerSecond: 0,
         successRate: 6,
     },
+    {
+        name: 'Ancient Tribe',
+        level: 105,
+        exp: 1150,
+        seconds: 80,
+        expPerSecond: 14.38,
+        goldValue: 0,
+        goldPerSecond: 0,
+        successRate: 5,
+    },
 ];

--- a/utils/gamedata/smithing-items.ts
+++ b/utils/gamedata/smithing-items.ts
@@ -125,6 +125,18 @@ export const SMITHING_ITEMS: SmithingItem[] = [
         oreBarsNeeded: 1, // Ore bars needed
         coalNeeded: 5000, // Coal needed
     },
+    {
+        name: 'Otherworldly Bar',
+        level: 102,
+        exp: 5000,
+        seconds: 60,
+        expPerSecond: 83.33,
+        goldValue: 100000,
+        goldPerSecond: 1666.67,
+        category: 'Bars',
+        oreBarsNeeded: 1, // Otherworldly ore needed
+        coalNeeded: 10000, // Coal needed
+    },
 
     // Bronze Equipment
     {
@@ -584,5 +596,51 @@ export const SMITHING_ITEMS: SmithingItem[] = [
         goldPerSecond: 33333.3,
         category: 'Astronomical Equipment',
         oreBarsNeeded: 4, // Astronomical bars needed
+    },
+
+    // Otherworldly Equipment
+    {
+        name: 'Otherworldly Helmet',
+        level: 104,
+        exp: 2000,
+        seconds: 9,
+        expPerSecond: 222.22,
+        goldValue: 300000,
+        goldPerSecond: 33333.33,
+        category: 'Otherworldly Equipment',
+        oreBarsNeeded: 2, // Otherworldly bars needed
+    },
+    {
+        name: 'Otherworldly Shield',
+        level: 106,
+        exp: 4000,
+        seconds: 9,
+        expPerSecond: 444.44,
+        goldValue: 600000,
+        goldPerSecond: 66666.67,
+        category: 'Otherworldly Equipment',
+        oreBarsNeeded: 4, // Otherworldly bars needed
+    },
+    {
+        name: 'Otherworldly Platelegs',
+        level: 108,
+        exp: 4000,
+        seconds: 9,
+        expPerSecond: 444.44,
+        goldValue: 600000,
+        goldPerSecond: 66666.67,
+        category: 'Otherworldly Equipment',
+        oreBarsNeeded: 4, // Otherworldly bars needed
+    },
+    {
+        name: 'Otherworldly Platebody',
+        level: 110,
+        exp: 6000,
+        seconds: 9,
+        expPerSecond: 666.67,
+        goldValue: 900000,
+        goldPerSecond: 100000,
+        category: 'Otherworldly Equipment',
+        oreBarsNeeded: 6, // Otherworldly bars needed
     },
 ];

--- a/utils/gamedata/woodcutting-items.ts
+++ b/utils/gamedata/woodcutting-items.ts
@@ -91,4 +91,13 @@ export const WOODCUTTING_ITEMS: SkillItem[] = [
         goldValue: 110,
         goldPerSecond: 5.5,
     },
+    {
+        name: 'Ignis',
+        level: 105,
+        exp: 935,
+        seconds: 150,
+        expPerSecond: 6.23,
+        goldValue: 150,
+        goldPerSecond: 1.0,
+    },
 ];


### PR DESCRIPTION
- Add new items from game update: Ancient Tribe, Ignis, Otherworldly Bar/Gear, Apex Meat, Smoldering Mushroom, Sunfire Berry, Dragonfire Potion, Ignis Heartwood, Sunfire Summit
- Move Skill Boosts section above General Buffs in calculator layout
- Auto-fill Skill Boosts when loading player: tool T5 at 90+, T6 at 100+; T3 Scrolls set to 4 at 90+