### PR TITLE
Fix/leaderboard rankings

### DIFF
--- a/app/(data)/rankings/page.tsx
+++ b/app/(data)/rankings/page.tsx
@@ -208,6 +208,8 @@ export default function RankingsPage() {
           entries={leaderboardEntries}
           isLoading={loading}
           entityType={entityType}
+          category={category}
+          stat={selectedStat}
         />
 
         {leaderboardEntries.length > 0 && hasMore && entityType !== 'clan' && (

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+
+const EXTERNAL_API_BASE = 'https://query.idleclans.com/api';
+const CACHE_MAX_AGE = 3600;
+const STALE_WHILE_REVALIDATE = 600;
+
+export async function GET(request: Request) {
+    const { searchParams } = new URL(request.url);
+
+    const leaderboardName = searchParams.get('leaderboardName');
+    const name = searchParams.get('name');
+    const startCount = searchParams.get('startCount') ?? '1';
+    const maxCount = searchParams.get('maxCount') ?? '100';
+
+    if (!leaderboardName || !name) {
+        return NextResponse.json(
+            { error: 'leaderboardName and name parameters are required' },
+            { status: 400 }
+        );
+    }
+
+    const upstreamUrl = new URL(
+        `${EXTERNAL_API_BASE}/Leaderboard/top/${encodeURIComponent(leaderboardName)}/${encodeURIComponent(name)}`
+    );
+    upstreamUrl.searchParams.set('startCount', startCount);
+    upstreamUrl.searchParams.set('maxCount', maxCount);
+
+    try {
+        const upstream = await fetch(upstreamUrl.toString(), {
+            next: { revalidate: CACHE_MAX_AGE },
+        });
+
+        if (!upstream.ok) {
+            return NextResponse.json(
+                { error: `Upstream API error: ${upstream.status}` },
+                { status: upstream.status }
+            );
+        }
+
+        const data = await upstream.json();
+
+        return NextResponse.json(data, {
+            headers: {
+                'Cache-Control': `s-maxage=${CACHE_MAX_AGE}, stale-while-revalidate=${STALE_WHILE_REVALIDATE}`,
+            },
+        });
+    } catch (error) {
+        return NextResponse.json(
+            { error: error instanceof Error ? error.message : 'Failed to fetch leaderboard data' },
+            { status: 500 }
+        );
+    }
+}

--- a/components/leaderboard/LeaderboardTable.tsx
+++ b/components/leaderboard/LeaderboardTable.tsx
@@ -1,16 +1,31 @@
 "use client";
 
 import Link from "next/link";
-import { LeaderboardEntry } from "@/types/leaderboard.types";
+import { LeaderboardEntry, LeaderboardCategory, LeaderboardStat } from "@/types/leaderboard.types";
 import { FaTrophy, FaMedal, FaAward } from "react-icons/fa";
 
 interface Props {
   entries: LeaderboardEntry[];
   isLoading?: boolean;
   entityType?: 'player' | 'clan' | 'pet';
+  category?: LeaderboardCategory;
+  stat?: LeaderboardStat | null;
 }
 
-const formatNum = (n: number) => new Intl.NumberFormat().format(Math.round(n));
+const NET_EPOCH_OFFSET = 621_355_968_000_000_000;
+
+function ticksToDate(ticks: number | null): string | null {
+  if (!ticks || ticks <= 0) return null;
+  const ms = (ticks - NET_EPOCH_OFFSET) / 10_000;
+  const d = new Date(ms);
+  const dd = d.getUTCDate().toString().padStart(2, "0");
+  const mm = (d.getUTCMonth() + 1).toString().padStart(2, "0");
+  return `${dd}.${mm}.${d.getUTCFullYear()}`;
+}
+
+function formatExp(exp: number): string {
+  return new Intl.NumberFormat().format(Math.round(exp));
+}
 
 const getRankIcon = (rank: number) => {
   if (rank === 1) return <FaTrophy className="text-yellow-400" />;
@@ -26,7 +41,19 @@ const getRankColor = (rank: number) => {
   return "text-gray-300";
 };
 
-export default function LeaderboardTable({ entries, isLoading = false, entityType = 'player' }: Props) {
+const ENTITY_LABEL: Record<string, string> = {
+  player: "Player",
+  clan: "Clan",
+  pet: "Pet",
+};
+
+export default function LeaderboardTable({
+  entries,
+  isLoading = false,
+  entityType = 'player',
+  category = 'skills',
+  stat = null,
+}: Props) {
   if (isLoading) {
     return (
       <div className="bg-white/5 border border-white/10 rounded-2xl shadow-xl backdrop-blur-xl overflow-hidden">
@@ -47,21 +74,42 @@ export default function LeaderboardTable({ entries, isLoading = false, entityTyp
     );
   }
 
+  const isSkillCategory = category === 'skills';
+  const isTotalLevel = isSkillCategory && stat === 'total_level';
+  const showDateColumn = isSkillCategory && !isTotalLevel;
+  const entityLabel = ENTITY_LABEL[entityType] ?? "Player";
+
   return (
     <div className="bg-white/5 border border-white/10 rounded-2xl shadow-xl backdrop-blur-xl overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full">
           <thead className="bg-white/5 border-b border-white/10">
             <tr>
-              <th className="px-6 py-4 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+              <th className="px-6 py-4 text-left text-xs font-medium text-gray-400 uppercase tracking-wider w-28">
                 Rank
               </th>
               <th className="px-6 py-4 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-                Player
+                {entityLabel}
               </th>
-              <th className="px-6 py-4 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">
-                Value
-              </th>
+              {isSkillCategory ? (
+                <>
+                  <th className="px-6 py-4 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">
+                    Level
+                  </th>
+                  <th className="px-6 py-4 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">
+                    Exp
+                  </th>
+                  {showDateColumn && (
+                    <th className="px-6 py-4 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">
+                      Cap Date
+                    </th>
+                  )}
+                </>
+              ) : (
+                <th className="px-6 py-4 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">
+                  Score
+                </th>
+              )}
             </tr>
           </thead>
           <tbody className="divide-y divide-white/5">
@@ -96,11 +144,33 @@ export default function LeaderboardTable({ entries, isLoading = false, entityTyp
                     </div>
                   )}
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-right">
-                  <div className="text-sm text-emerald-400 font-mono">
-                    {formatNum(entry.value)}
-                  </div>
-                </td>
+                {isSkillCategory ? (
+                  <>
+                    <td className="px-6 py-4 whitespace-nowrap text-right">
+                      <span className="text-sm text-white font-mono font-semibold">
+                        {entry.level.toLocaleString()}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-right">
+                      <span className="text-sm text-emerald-400 font-mono">
+                        {formatExp(entry.exp)}
+                      </span>
+                    </td>
+                    {showDateColumn && (
+                      <td className="px-6 py-4 whitespace-nowrap text-right">
+                        <span className="text-sm text-gray-400 font-mono">
+                          {ticksToDate(entry.expCapDate) ?? "—"}
+                        </span>
+                      </td>
+                    )}
+                  </>
+                ) : (
+                  <td className="px-6 py-4 whitespace-nowrap text-right">
+                    <span className="text-sm text-emerald-400 font-mono">
+                      {entry.exp.toLocaleString()}
+                    </span>
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>

--- a/hooks/queries/useLeaderboardQuery.ts
+++ b/hooks/queries/useLeaderboardQuery.ts
@@ -52,7 +52,7 @@ export function useLeaderboardQuery(
                 : undefined;
         },
         enabled: stat !== null,
-        staleTime: 30 * 60 * 1000,
+        staleTime: 60 * 60 * 1000,
     });
 
     const entries = useMemo<LeaderboardEntry[]>(

--- a/lib/api/apiService.ts
+++ b/lib/api/apiService.ts
@@ -9,6 +9,7 @@ interface LeaderboardApiEntry {
     name?: string;
     level?: number;
     score?: number;
+    expCapDate?: number;
 }
 
 export const fetchPlayerProfile = async (username: string): Promise<Player> => {
@@ -91,15 +92,22 @@ export const fetchLeaderboard = async (
     category: LeaderboardCategory,
     stat: LeaderboardStat,
     startCount: number = 1,
-    maxCount: number = 100
+    pageSize: number = 100
 ): Promise<LeaderboardData> => {
     try {
-        const leaderboardName = entityType === 'pet' ? `pets:${gameMode}` : `${entityType}s:${gameMode}`;
+        const apiGameMode = gameMode.replace(/_/g, '');
+        const leaderboardName = entityType === 'pet' ? `pets:${apiGameMode}` : `${entityType}s:${apiGameMode}`;
+        const endCount = startCount + pageSize - 1;
         const response = await axios.get(
-            `${API_BASE_URL}/Leaderboard/top/${leaderboardName}/${stat}`,
+            '/api/leaderboard',
             {
                 timeout: DEFAULT_TIMEOUT,
-                params: { startCount, maxCount }
+                params: {
+                    leaderboardName,
+                    name: stat,
+                    startCount,
+                    maxCount: endCount,
+                }
             }
         );
 
@@ -110,7 +118,10 @@ export const fetchLeaderboard = async (
             entries = response.data.map((entry: LeaderboardApiEntry, index: number) => ({
                 rank: startCount + index,
                 name: entry.username || entry.name || `Player ${startCount + index}`,
-                value: isTotalLevel ? (entry.level || 0) : (entry.score || 0)
+                value: isTotalLevel ? (entry.level || 0) : (entry.score || 0),
+                level: entry.level || 0,
+                exp: entry.score || 0,
+                expCapDate: entry.expCapDate ?? null,
             }));
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idleclanshub",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Idle Clans Hub - Your ultimate Idle Clans companion is here. Unlock the full potential of your game in one powerful, unified platform.",
   "author": "Karol \"HSKdev\" Has",
   "license": "MIT",

--- a/types/leaderboard.types.ts
+++ b/types/leaderboard.types.ts
@@ -18,6 +18,9 @@ export interface LeaderboardEntry {
   rank: number;
   name: string;
   value: number;
+  level: number;
+  exp: number;
+  expCapDate: number | null;
 }
 
 export interface LeaderboardData {


### PR DESCRIPTION
- Fix maxCount API param (ending position, not count) to resolve 400 on Load Next 100
- Add Next.js proxy route /api/leaderboard with 1h Cache-Control
- Extend LeaderboardEntry with level, exp, expCapDate; add Level/Exp/Cap Date columns
- Format exp as full numbers (no abbreviations)
- Fix group_ironman game mode (API expects groupironman, not group_ironman)
- Bump TanStack Query staleTime to 1 hour